### PR TITLE
Fix the build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 description = "ZFS snapshot wrapper utility"
 readme = "README.md"
-license = "BSD-2-clause"
+license = {file = "LICENSE"}
 keywords = ["zfs"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Providing both a `LICENSE` file and a hardcoded license in the `pyproject.toml`
file breaks setuptools.

Provide just the file key to unbreak the CI build.